### PR TITLE
[fix]Fix withStyles with RPureComponent

### DIFF
--- a/core/src/main/kotlin/materialui/styles/withStyles.kt
+++ b/core/src/main/kotlin/materialui/styles/withStyles.kt
@@ -20,13 +20,13 @@ fun <P: RProps> withStyles(
     js { this["withTheme"] = withTheme }
 )(rClass).unsafeCast<RClass<P>>()
 
-fun <C : RComponent<P, *>, P : RProps> withStyles(
+fun <C : Component<P, *>, P : RProps> withStyles(
     klazz: KClass<C>,
     styleSet: StylesSet.() -> Unit,
     withTheme: Boolean = false
-): RClass<P> = withStyles(klazz.rClass, styleSet, withTheme = withTheme)
+): RClass<P> = withStyles(klazz.js.unsafeCast<RClass<P>>(), styleSet, withTheme = withTheme)
 
-fun <P : RProps, C : RComponent<P, *>> RBuilder.childWithStyles(
+fun <P : RProps, C : Component<P, *>> RBuilder.childWithStyles(
     klazz: KClass<C>,
     styleSet: StylesSet.() -> Unit,
     withTheme: Boolean = false,


### PR DESCRIPTION
I broke my own use-case in #12 :rofl: The change to RComponent breaks compatibility with RPureComponent.

I've switched back to manually calling `unsafeCast<RClass<P>>`,  which works for both.

I will try to submit a pull request to kotlin-react later, I believe this shoud be fixed in react.rClass