### PR TITLE
Deprecate childWithStyles

### DIFF
--- a/core/src/main/kotlin/materialui/styles/withStyles.kt
+++ b/core/src/main/kotlin/materialui/styles/withStyles.kt
@@ -26,6 +26,16 @@ fun <C : Component<P, *>, P : RProps> withStyles(
     withTheme: Boolean = false
 ): RClass<P> = withStyles(klazz.js.unsafeCast<RClass<P>>(), styleSet, withTheme = withTheme)
 
+fun <P: RProps> withStyles(
+    displayName: String,
+    styleSet: StylesSet.() -> Unit,
+    withTheme: Boolean = false,
+    render: RBuilder.(P) -> Unit
+): RClass<P> = withStyles(rFunction(displayName, render), styleSet, withTheme = withTheme)
+
+@Deprecated(
+    "Use withStyles to create a reusable RClass instead, and call that to render the styled component."
+)
 fun <P : RProps, C : Component<P, *>> RBuilder.childWithStyles(
     klazz: KClass<C>,
     styleSet: StylesSet.() -> Unit,
@@ -37,6 +47,10 @@ fun <P : RProps, C : Component<P, *>> RBuilder.childWithStyles(
     return rClass(handler)
 }
 
+@Deprecated(
+    "Use withStyles instead",
+    replaceWith = ReplaceWith("withStyles(displayName, styleSet, withTheme, render)", "materialui.styles.withStyles")
+)
 fun <P: RProps> RBuilder.childWithStyles(
     displayName: String,
     styleSet: StylesSet.() -> Unit,

--- a/sample/src/main/kotlin/demo/components/AppbarsDemo.kt
+++ b/sample/src/main/kotlin/demo/components/AppbarsDemo.kt
@@ -12,16 +12,13 @@ import materialui.components.toolbar.toolbar
 import materialui.components.typography.enums.TypographyColor
 import materialui.components.typography.enums.TypographyVariant
 import materialui.components.typography.typography
-import materialui.styles.StylesSet
-import materialui.styles.childWithStyles
+import materialui.styles.withStyles
 import react.RBuilder
 import react.RComponent
 import react.RProps
 import react.RState
 import react.dom.div
-import react.dom.h1
 import styled.styledH1
-import styled.styledH2
 
 class AppbarsDemo : RComponent<RProps, RState>() {
     override fun RBuilder.render() {
@@ -75,12 +72,10 @@ class AppbarsDemo : RComponent<RProps, RState>() {
     }
 
     companion object {
-        fun render(rBuilder: RBuilder) = rBuilder.childWithStyles(
-            AppbarsDemo::class,
-            styleSets
-        ) {  }
 
-        private val styleSets: StylesSet.() -> Unit = {
+        fun render(rBuilder: RBuilder) = with (rBuilder) { styledComponent { } }
+
+        private val styledComponent = withStyles(AppbarsDemo::class, {
             "root" {
                 flexGrow = 1.0
             }
@@ -91,6 +86,6 @@ class AppbarsDemo : RComponent<RProps, RState>() {
                 marginLeft = (-12).px
                 marginRight = 20.px
             }
-        }
+        })
     }
 }

--- a/sample/src/main/kotlin/demo/components/ButtonsDemo.kt
+++ b/sample/src/main/kotlin/demo/components/ButtonsDemo.kt
@@ -9,8 +9,8 @@ import materialui.components.button.enums.ButtonVariant
 import materialui.components.typography.enums.TypographyVariant
 import materialui.components.typography.typography
 import materialui.styles.StylesSet
-import materialui.styles.childWithStyles
 import materialui.styles.muitheme.spacing
+import materialui.styles.withStyles
 import react.RBuilder
 import react.RComponent
 import react.RProps
@@ -119,18 +119,15 @@ class ButtonsDemo : RComponent<RProps, RState>() {
     }
 
     companion object {
-        fun render(rBuilder: RBuilder) = rBuilder.childWithStyles(
-            ButtonsDemo::class,
-            styles
-        ) { }
+        fun render(rBuilder: RBuilder) = with (rBuilder) { styledComponent {} }
 
-        private val styles: StylesSet.() -> Unit = {
+        private val styledComponent = withStyles(ButtonsDemo::class, {
             "button" {
                 margin(theme.spacing(1))
             }
             "input" {
                 display = Display.none
             }
-        }
+        })
     }
 }

--- a/sample/src/main/kotlin/demo/components/InputAdornmentsDemo.kt
+++ b/sample/src/main/kotlin/demo/components/InputAdornmentsDemo.kt
@@ -3,7 +3,6 @@ package demo.components
 import kotlinx.css.*
 import kotlinx.html.DIV
 import kotlinx.html.js.onChangeFunction
-import materialui.styles.StylesSet
 import materialui.components.formcontrol.formControl
 import materialui.components.input.input
 import materialui.components.inputadornment.InputAdornmentElementBuilder
@@ -11,16 +10,13 @@ import materialui.components.inputadornment.enums.InputAdornmentPosition
 import materialui.components.inputlabel.inputLabel
 import materialui.components.menuitem.menuItem
 import materialui.components.textfield.textField
-import materialui.styles.childWithStyles
+import materialui.styles.withStyles
 import org.w3c.dom.events.Event
 import react.*
 import react.dom.div
-import react.dom.h1
-import react.dom.h2
 import styled.css
 import styled.styledDiv
 import styled.styledH1
-import styled.styledH2
 
 val ranges: List<Pair<String, String>>
     get() = listOf(
@@ -140,12 +136,9 @@ class InputAdornmentsDemo : RComponent<RProps, InputAdornmentsState>() {
         }
 
     companion object {
-        fun render(rBuilder: RBuilder) = rBuilder.childWithStyles(
-            InputAdornmentsDemo::class,
-            style
-        ) { }
+        fun render(rBuilder: RBuilder) = with(rBuilder) { styledComponent { } }
 
-        private val style: StylesSet.() -> Unit = {
+        private val styledComponent = withStyles(InputAdornmentsDemo::class, {
             "root" {
                 display = Display.flex
                 flexWrap = FlexWrap.wrap
@@ -160,7 +153,7 @@ class InputAdornmentsDemo : RComponent<RProps, InputAdornmentsState>() {
             "textField" {
                 flexBasis = 200.px.basis
             }
-        }
+        })
     }
 }
 

--- a/sample/src/main/kotlin/demo/components/appsearch/AppSearch.kt
+++ b/sample/src/main/kotlin/demo/components/appsearch/AppSearch.kt
@@ -2,8 +2,6 @@ package demo.components.appsearch
 
 import kotlinx.css.*
 import kotlinx.css.properties.TextDecoration
-import materialui.styles.StylesSet
-import materialui.styles.childWithStyles
 import materialui.styles.muitheme.shadows
 import materialui.styles.muitheme.spacing
 import materialui.styles.palette.*
@@ -11,15 +9,12 @@ import materialui.styles.transitions.create
 import materialui.styles.typography.fontWeightMedium
 import materialui.styles.typography.fontWeightRegular
 import materialui.styles.typography.typography
+import materialui.styles.withStyles
 import react.RBuilder
 
-fun RBuilder.appSearch(handler: RBuilder.() -> Unit) = childWithStyles(
-    AppSearchComponent::class,
-    appSearchStyles,
-    handler = handler
-)
+fun RBuilder.appSearch(handler: RBuilder.() -> Unit) = styledAppSearch(handler)
 
-private val appSearchStyles: StylesSet.() -> Unit = {
+private val styledAppSearch = withStyles(AppSearchComponent::class, {
     "@global" {
         ".algolia-autocomplete" {
             descendants(".ds-dropdown-menu") {
@@ -109,4 +104,4 @@ private val appSearchStyles: StylesSet.() -> Unit = {
     "inputInput" {
         padding = theme.spacing(top = 1, bottom = 1, right = 1, left = 9)
     }
-}
+})

--- a/sample/src/main/kotlin/demo/components/header/Header.kt
+++ b/sample/src/main/kotlin/demo/components/header/Header.kt
@@ -3,7 +3,6 @@ package demo.components.header
 import demo.components.appsearch.appSearch
 import kotlinx.css.*
 import kotlinx.css.properties.BoxShadows
-import materialui.styles.StylesSet
 import materialui.components.appbar.appBar
 import materialui.components.button.enums.ButtonColor
 import materialui.components.cssbaseline.cssBaseline
@@ -13,8 +12,8 @@ import materialui.components.toolbar.toolbar
 import materialui.components.tooltip.tooltip
 import materialui.styles.breakpoint.Breakpoint
 import materialui.styles.breakpoint.up
-import materialui.styles.childWithStyles
 import materialui.styles.transitions.create
+import materialui.styles.withStyles
 import react.RBuilder
 import react.RComponent
 import react.RState
@@ -116,12 +115,9 @@ class Header : RComponent<HeaderProps, RState>() {
     }
 
     companion object {
-        fun render(rBuilder: RBuilder) = rBuilder.childWithStyles(
-            Header::class,
-            style
-        ) { }
+        fun render(rBuilder: RBuilder) = with (rBuilder) { styledComponent {} }
 
-        private val style: StylesSet.() -> Unit = {
+        private val styledComponent = withStyles(Header::class, {
             "root" {
                 display = Display.flex
             }
@@ -156,6 +152,6 @@ class Header : RComponent<HeaderProps, RState>() {
                     display = Display.none
                 }
             }
-        }
+        })
     }
 }


### PR DESCRIPTION
This pull request takes the changes from #12 one step further, by adding a final new variant of withStyles for function components, and deprecating childWithStyles and replacing it in all the samples.

Motivation: the childWithStyles variants always create a new component on each invocation, which prevents reconciliation of such components.

Instead, withStyles should be used to store the created higher order component in a RClass variable and call that to render the component.

This is also more similar to the original React API naming.

As a nice side-effect, this makes it much nicer to pass the styles directly to the withStyles function (see samples), which allows to omit the `StyleSets.() -> Unit` signature.