### PR TITLE
Update kotlin-wrappers to pre.98

### DIFF
--- a/buildSrc/src/main/java/Libraries.kt
+++ b/buildSrc/src/main/java/Libraries.kt
@@ -8,23 +8,25 @@ object Libraries {
 
     object Kotlin {
         const val version = "1.3.72"
+        const val wrappersBuild = "pre.98-kotlin-$version"
+
         const val js = "org.jetbrains.kotlin:kotlin-stdlib-js:$version"
         const val jsTest = "org.jetbrains.kotlin:kotlin-test-js:$version"
 
-        const val reactVersion = "${Npm.react}-pre.97-kotlin-$version"
+        const val reactVersion = "${Npm.react}-$wrappersBuild"
         const val react = "org.jetbrains:kotlin-react:$reactVersion"
         const val reactDom = "org.jetbrains:kotlin-react-dom:$reactVersion"
 
         const val htmlVersion = "0.7.1"
         const val html = "org.jetbrains.kotlinx:kotlinx-html-js:$htmlVersion"
 
-        const val cssVersion = "1.0.0-pre.97-kotlin-$version"
+        const val cssVersion = "1.0.0-$wrappersBuild"
         const val css = "org.jetbrains:kotlin-css-js:$cssVersion"
 
-        const val styledVersion = "1.0.0-pre.97-kotlin-$version"
+        const val styledVersion = "1.0.0-$wrappersBuild"
         const val styled = "org.jetbrains:kotlin-styled:$styledVersion"
 
-        const val extensionsVersion = "1.0.1-pre.97-kotlin-$version"
+        const val extensionsVersion = "1.0.1-$wrappersBuild"
         const val extensions = "org.jetbrains:kotlin-extensions:$extensionsVersion"
     }
 

--- a/core/src/main/kotlin/materialui/styles/withStyles.kt
+++ b/core/src/main/kotlin/materialui/styles/withStyles.kt
@@ -24,7 +24,7 @@ fun <C : Component<P, *>, P : RProps> withStyles(
     klazz: KClass<C>,
     styleSet: StylesBuilder<P>.() -> Unit,
     withTheme: Boolean = false
-): RClass<P> = withStyles(klazz.js.unsafeCast<RClass<P>>(), styleSet, withTheme = withTheme)
+): RClass<P> = withStyles(klazz.rClass, styleSet, withTheme = withTheme)
 
 fun <P: RProps> withStyles(
     displayName: String,


### PR DESCRIPTION
* Simplify wrappers version selection in buildSrc/Libraries.kt
* Update to kotlin-wrappers pre.98
* Use KClass.rClass that is now publicly available (see also #13)