### PR TITLE
[update]Update kotlin-wrappers -> pre.104

### DIFF
--- a/buildSrc/src/main/java/Libraries.kt
+++ b/buildSrc/src/main/java/Libraries.kt
@@ -8,7 +8,7 @@ object Libraries {
 
     object Kotlin {
         const val version = "1.3.72"
-        const val wrappersBuild = "pre.100-kotlin-$version"
+        const val wrappersBuild = "pre.104-kotlin-$version"
 
         const val js = "org.jetbrains.kotlin:kotlin-stdlib-js:$version"
         const val jsTest = "org.jetbrains.kotlin:kotlin-test-js:$version"
@@ -31,14 +31,13 @@ object Libraries {
     }
 
     object Npm {
-        const val coreJs = "~3.1.4"
-        const val styledComponent = "^4.3.2"
-        const val inlineStyledPrefixer = "^5.1.0"
+        const val styledComponent = "^4.4.1"
+        const val inlineStyledPrefixer = "^5.1.2"
         const val react = "16.13.1"
 
         object MaterialUi {
-            const val core = "4.9.8"
-            const val lab = "4.0.0-alpha.47"
+            const val core = "4.9.12"
+            const val lab = "4.0.0-alpha.51"
         }
     }
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -32,14 +32,12 @@ kotlin {
         val main by getting {
             dependencies {
                 implementation(Libraries.Kotlin.js)
-                implementation(Libraries.Kotlin.html)
-                implementation(Libraries.Kotlin.react)
-                implementation(Libraries.Kotlin.reactDom)
-                implementation(Libraries.Kotlin.css)
+                api(Libraries.Kotlin.html)
+                api(Libraries.Kotlin.react)
+                api(Libraries.Kotlin.reactDom)
+                api(Libraries.Kotlin.css)
                 implementation(Libraries.Kotlin.extensions)
-                implementation(npm("react", Libraries.Npm.react))
-                implementation(npm("react-dom", Libraries.Npm.react))
-                implementation(npm("@material-ui/core", Libraries.Npm.MaterialUi.core))
+                api(npm("@material-ui/core", Libraries.Npm.MaterialUi.core))
             }
         }
 

--- a/lab/build.gradle.kts
+++ b/lab/build.gradle.kts
@@ -31,17 +31,10 @@ kotlin {
     sourceSets {
         val main by getting {
             dependencies {
-                implementation(project(":core"))
+                api(project(":core"))
                 implementation(Libraries.Kotlin.js)
-                implementation(Libraries.Kotlin.html)
-                implementation(Libraries.Kotlin.react)
-                implementation(Libraries.Kotlin.reactDom)
-                implementation(Libraries.Kotlin.css)
                 implementation(Libraries.Kotlin.extensions)
-                implementation(npm("react", Libraries.Npm.react))
-                implementation(npm("react-dom", Libraries.Npm.react))
-                implementation(npm("@material-ui/core", Libraries.Npm.MaterialUi.core))
-                implementation(npm("@material-ui/lab", Libraries.Npm.MaterialUi.lab))
+                api(npm("@material-ui/lab", Libraries.Npm.MaterialUi.lab))
             }
         }
 

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -40,16 +40,7 @@ kotlin {
                 implementation(project(":core"))
                 implementation(project(":lab"))
                 implementation(Libraries.Kotlin.js)
-                implementation(Libraries.Kotlin.html)
-                implementation(Libraries.Kotlin.react)
-                implementation(Libraries.Kotlin.reactDom)
-                implementation(Libraries.Kotlin.css)
                 implementation(Libraries.Kotlin.styled)
-                implementation(Libraries.Kotlin.extensions)
-                implementation(npm("react", Libraries.Npm.react))
-                implementation(npm("react-dom", Libraries.Npm.react))
-                implementation(npm("styled-components", Libraries.Npm.styledComponent))
-                implementation(npm("inline-style-prefixer", Libraries.Npm.inlineStyledPrefixer))
             }
         }
 


### PR DESCRIPTION
Update to kotlin-wrappers pre.104. They have changed their setup to export all dependencies as api scope. This definitely makes sense for gradle-dependencies (like kotlin-react-dom -> kotlin-react), for npm it's probably fine as well.

However, it leads to some warnings in the initial kotlinNpmInstall task about missing peer dependencies. However, those dependencies are available in the end.

I have adjusted the build files to follow the kotlin-wrappers change: the @material-ui npm dependencies are now exported as api. I have updated them to the latest version.

All kotlin-wrappers libraries that are part of this library's public API are now correctly marked as api as well.

I have removed all superfluous dependency declarations where applicable.

I'm not totally happy with the warnings. Please let me know what you think about this.