### PR TITLE
Fix build error due to Kotlin version inconsistency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ subprojects {
 fun Project.jsPlugin() {
     plugins.withType<KotlinJsPluginWrapper> {
         extensions.configure<KotlinJsProjectExtension> {
-            js {
+            js(BOTH) {
                 browser()
             }
 

--- a/buildSrc/src/main/java/Libraries.kt
+++ b/buildSrc/src/main/java/Libraries.kt
@@ -17,7 +17,7 @@ object Libraries {
         const val react = "org.jetbrains:kotlin-react:$reactVersion"
         const val reactDom = "org.jetbrains:kotlin-react-dom:$reactVersion"
 
-        const val htmlVersion = "0.7.1"
+        const val htmlVersion = "0.7.2"
         const val html = "org.jetbrains.kotlinx:kotlinx-html-js:$htmlVersion"
 
         const val cssVersion = "1.0.0-$wrappersBuild"

--- a/buildSrc/src/main/java/maven-publishing.gradle.kts
+++ b/buildSrc/src/main/java/maven-publishing.gradle.kts
@@ -47,6 +47,7 @@ publishing.publications {
     create<MavenPublication>("ToMavenPublication") {
         from(components["kotlin"])
         artifact(tasks.getByName<Zip>("jsLegacySourcesJar"))
+        artifact(tasks.getByName<Zip>("jsIrSourcesJar"))
         groupId = group
         artifactId = project.name
         version = libVersion

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,7 +1,7 @@
 pluginManagement {
     resolutionStrategy {
         plugins {
-            kotlin("js") version "1.4.0"
+            kotlin("js") version "1.4.10"
         }
     }
 }


### PR DESCRIPTION
Fixed a problem related to IR Backend introduced in Kotlin 1.4, such as not being able to refer to the core project from the examples subproject.

Changelog:
* Changed the JS backend output by core etc. to "BOTH".
* Updated kotlinx-html to resolve issues with multiple versions of Kotlin being included in the classpath due to transitive dependencies.
* Changed to upload IR backend artifacts to maven as well.
* Updated Kotlin/JS Gradle plugin for dependency integrity.

Japanese:
Kotlin 1.3.xから1.4.xへの更新でIRバックエンドのサポートが追加されています。これに関連し、ビルド時にエラーが発生していたようなので修正を行いました。(IRバックエンドとレガシーバックエンドの成果物には互換性がありません。)

* exampleプロジェクトがIRバックエンドの成果物を要求しているにもかかわらず、IRの成果物を生成していないためエラーが起きていた問題を修正するため、coreなどexamples以外のサブプロジェクトがIRバックエンドの成果物も生成するよう変更しました。
* Kotlin 1.3.xと1.4.xが同時に依存関係に含まれる場合、1.3.xがIRに対応していないことに起因した問題が発生するため、kotlinx-htmlをKotlin 1.4.10に依存するバージョンに更新しました。
* MavenリポジトリにIRバックエンドの成果物もアップロードするよう変更しました。
* 各種依存ライブラリが1.4.10に依存しているのに対し本プロジェクトのGradle Pluginが1.4.0だったため、1.4.10に更新しました。