### PR TITLE
Fix typo for autocomplete lab module

### DIFF
--- a/lab/src/main/kotlin/materialui/lab/components/autocomplete/autoComplete.kt
+++ b/lab/src/main/kotlin/materialui/lab/components/autocomplete/autoComplete.kt
@@ -11,7 +11,7 @@ import materialui.lab.components.autocomplete.enums.AutocompleteStyle
 import materialui.lab.components.useautocomplete.UseAutocompleteProps
 import react.*
 
-@JsModule("@material-ui/lab/AutoComplete")
+@JsModule("@material-ui/lab/Autocomplete")
 @JsNonModule
 private external val autocompleteModule: dynamic
 


### PR DESCRIPTION
Hi, 

We found this typo in the autocomplete functionality.

According to https://material-ui.com/api/autocomplete/#autocomplete-api, the module name should be `Autocomplete`, and not `AutoComplete`.

That typo is actually problematic when using webpack or development run in a linux environment as the OS is case-senstive.

You can try it by running the samples (`./gradlew :sample:browserDevelopmentRun`). For us, before this fix, running the samples from a linux environment showed a blank page with the following message in the console:

```
Cannot find module '@material-ui/lab/AutoComplete'
```

We'd be thankful it this fix could be published urgently.  :-)