### PR TITLE
Bump wrappers to pre.282, to support Kotlin 1.6.10

### DIFF
--- a/buildSrc/src/main/java/Libraries.kt
+++ b/buildSrc/src/main/java/Libraries.kt
@@ -1,12 +1,13 @@
 @Suppress("unused")
 object Libraries {
     class JsWrappers(kotlinVersion: String) {
-        private val wrappersBuild = "pre.246-kotlin-$kotlinVersion"
+        private val wrappersBuild = "pre.282-kotlin-$kotlinVersion"
         private val prefix = "org.jetbrains.kotlin-wrappers:kotlin"
 
         private val reactVersion = "${Npm.react}-$wrappersBuild"
         val react = "$prefix-react:$reactVersion"
         val reactDom = "$prefix-react-dom:$reactVersion"
+        val reactDomLegacy = "$prefix-react-dom-legacy:$reactVersion"
 
         private val htmlVersion = "0.7.3"
         val html = "org.jetbrains.kotlinx:kotlinx-html-js:$htmlVersion"
@@ -22,7 +23,7 @@ object Libraries {
     }
 
     object Npm {
-        const val styledComponent = "5.3.1"
+        const val styledComponent = "5.3.3"
         const val inlineStyledPrefixer = "^5.1.2"
         const val react = "17.0.2"
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     api(wrappers.html)
     api(wrappers.react)
     api(wrappers.reactDom)
+    api(wrappers.reactDomLegacy)
     api(wrappers.css)
     api(wrappers.extensions)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 kotlin.js.compiler=both
 
-kotlin.version=1.5.30
+kotlin.version=1.6.10
 packages.group=net.subroh0508.kotlinmaterialui
 packages.version=0.7.0-CICDTEST


### PR DESCRIPTION
* Include `kotlin-react-dom-legacy` in dependencies.

Fixes #58.